### PR TITLE
2 fixes and small speed optimization.

### DIFF
--- a/app/code/local/Shiptheory/Shippinglabels/Model/Observer.php
+++ b/app/code/local/Shiptheory/Shippinglabels/Model/Observer.php
@@ -13,7 +13,7 @@ class Shiptheory_Shippinglabels_Model_Observer
 	    }
 
         $block = $observer->getEvent()->getBlock();
-        if(get_class($block) =='Mage_Adminhtml_Block_Widget_Grid_Massaction'
+        if($block instanceof Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract
             && $block->getRequest()->getControllerName() == 'sales_order')
         {
             $block->addItem('shippinglabels', array(

--- a/app/code/local/Shiptheory/Shippinglabels/controllers/Adminhtml/ShippinglabelsController.php
+++ b/app/code/local/Shiptheory/Shippinglabels/controllers/Adminhtml/ShippinglabelsController.php
@@ -41,7 +41,7 @@ class Shiptheory_Shippinglabels_Adminhtml_ShippinglabelsController extends Mage_
     		//only retry failed or pending
     		$collection->addFieldToFilter('status', array('in' => array(1,0)));
     		$ids = $collection->getData();
-    		$queued = $collection->count();
+    		$queued = $collection->getSize();
     		$failed_count = 0;$success_count = 0;
     		
     	}
@@ -205,7 +205,7 @@ class Shiptheory_Shippinglabels_Adminhtml_ShippinglabelsController extends Mage_
 			$order = Mage::getModel('sales/order')->load($order_id);
 			if($order->canShip()){
 			
-				$item_qty =  $order->getItemsCollection()->count();
+				$item_qty =  $order->getItemsCollection()->getSize();
 				$shipment = Mage::getModel('sales/service_order', $order)->prepareShipment($item_qty);
 				$shipment = new Mage_Sales_Model_Order_Shipment_Api();
 				

--- a/app/code/local/Shiptheory/Shippinglabels/etc/system.xml
+++ b/app/code/local/Shiptheory/Shippinglabels/etc/system.xml
@@ -12,7 +12,7 @@
 			<tab>shiptheory</tab>
 			<!--<class>shiptheory-section</class>-->
 			<frontend_type>text</frontend_type>
-			<sort_order>1</sort_order>
+			<sort_order>100</sort_order>
 			<show_in_default>1</show_in_default>
 			<show_in_website>1</show_in_website>
 			<show_in_store>1</show_in_store>


### PR DESCRIPTION
Fixed an issue with Enterprise Sale Order Grid - the Magento Enterprise mass action block isn't called "Mage_Adminhtml_Block_Widget_Grid_Massaction" and therefore the original code didn't work so use instance of on the abstract which makes it compatable with enterprise and also allows other people to rewrite that block.

The current for order for tabs is 1. Because magento oddly uses the tab sort orders to decide which page is displated when you go to system > configuration that means your extension page is allways displayed - not the end of the world but a little annoying. Note I notice the royal mail also has a sort order of 1 so you'd need to update all of those. http://magento.stackexchange.com/questions/13197/default-tab-selection-in-system-config

I also switched out a couple of collection -> count calls to ->getSize calls - this just means that the collection doesn't need to be loaded in order to count them.
